### PR TITLE
Fix hostname for debug page

### DIFF
--- a/dashboard/debug.html
+++ b/dashboard/debug.html
@@ -33,7 +33,7 @@
     </style>
 
     <script type="text/javascript">
-        let socket = new WebSocket("ws://callumpi:8765");
+        let socket = new WebSocket("ws://airquality:8765");
 
         socket.onmessage = function(event) {
             dataObj = JSON.parse(event.data);


### PR DESCRIPTION
The hostname used on the debug.html page doesn't match the device's hostname, this is a tiny patch to correct that